### PR TITLE
Exit if the final result of any command or pipeline is a failure

### DIFF
--- a/semver_version.sh
+++ b/semver_version.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 version_input="git"
 version_output="git"
 version_increment_type=""


### PR DESCRIPTION
We hit an issue with vamp-cloud-user-management where command to push
the new version tag to the remote repository failed, but the script
exited successfully.

This caused all subsequent vamp-cloud-user-management builds to try to
build the same version tag, since the remote (the source of truth for
tags) wasn't being updated.

This issue would have been detected earlier if the tag push failure
hadn't been a silent failure.

I have read through the script and haven't found any commands that are
expected to fail which aren't guarded via `||`.

I'd appreciate guidance on how best to test this script.