### PR TITLE
Set -e to the script to exit if any of the commands fail

### DIFF
--- a/semver_version.sh
+++ b/semver_version.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 version_input="git"
 version_output="git"
 version_increment_type=""


### PR DESCRIPTION
Currently if any of the commands fail, this script doesn't fail (e.g. when there are not write permissions in the git repository). Any error inside this script goes undetected during the circleci jobs.

By setting `set -e` the script will exist immediately when there is an error with the subcommands.